### PR TITLE
Testar download do REMOTE_MAKEFILE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cp -a .env ${{ env.test-directory }}
       - name: Test downloading version ${{ env.version-makefile }}
         run: |
-          sed -i -e s/VERSION_MAKEFILE=main/VERSION_MAKEFILE=${{ env.version-makefile }}/ .env
+          sed -i s/VERSION_MAKEFILE=main/VERSION_MAKEFILE=${{ env.version-makefile }}/ .env
           make
         working-directory: ${{ env.test-directory }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,23 @@ jobs:
   download-remote:
     name: "Test remote Makefile download"
     runs-on: ubuntu-18.04
+    env:
+      version-makefile: main
+      test-directory: ./test-download
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Create test directory
         run: |
-          mkdir -p ./test-download
-          cp -a Makefile ./test-download
-          cp -a .env ./test-download
-      - name: Run make command
+          mkdir -p ${{ env.test-directory }}
+          cp -a Makefile ${{ env.test-directory }}
+          cp -a .env ${{ env.test-directory }}
+      - name: Test downloading version ${{ env.version-makefile }}
         run: |
-          cd ./test-download
+          sed -i -e s/VERSION_MAKEFILE=main/VERSION_MAKEFILE=${{ env.version-makefile }}/ .env
           make
+        working-directory: ${{ env.test-directory }}
 
   terraform:
     name: "Unit Tests for Terraform"
@@ -34,4 +38,4 @@ jobs:
       - name: Make Test
         id: test
         run: make test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ jobs:
         run: |
           mkdir -p ./test-download
           cp -a Makefile ./test-download
+          cp -a .env ./test-download
       - name: Run make command
-        run: make
+        run: |
+          cd ./test-download
+          make
 
   terraform:
     name: "Unit Tests for Terraform"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Create test directory
         run: |
           mkdir -p ./test-download
@@ -26,7 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Make Test
         id: test
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
   pull_request:
 
 jobs:
+  download-remote:
+    name: "Test remote Makefile download"
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Create test directory
+        run: |
+          mkdir -p ./test-download
+          cp -a Makefile ./test-download
+      - name: Run make command
+        run: make
+
   terraform:
     name: "Unit Tests for Terraform"
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Este PR implementa o teste de download do REMOTE_MAKEFILE mencionado na issue #7 .

No momento, está testando a versão `main` pois ainda não foram geradas tags no repositório.