### PR TITLE
Inclui informação sobre uso do TF_VAR

### DIFF
--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -13,40 +13,9 @@ Exemplos para utilização do Makefile para Terraform.
 
 A implementação do Makefiles para Terraform está contida no arquivo `terraform.inc`. Esta implementação utiliza containeres Docker para execução dos comandos, referenciando a imagem `hashicorp/terraform:0.14.0`.
 
-## Como utilizar o template
+## Opções de _backend_
 
-### Configurando o _backend_
+O Terraform trabalha com [_backend_](https://www.terraform.io/docs/language/settings/backends/index.html) local ou remoto. Foram disponibilizados alguns exemplos de como utilizar o Makefile, de acordo com o _backend_ escolhido:
 
-O Terraform trabalha com [_backend_](https://www.terraform.io/docs/language/settings/backends/index.html) local ou remoto. Para usar este Makefile com **_backend_ local**, não é necessária nenhuma configuração adicional.
-
-Para configurar um **_backend_ remoto**, favor acessar a documentação específica:
-
+- [Terraform com _backend_ local](./local-backend)
 - [Terraform com _backend_ na GCP](./google-backend)
-
-
-### Executando o Terraform
-
-Começar utilizando os comandos `make` ou `make help`, para conhecer os comandos disponíveis para o Terraform.
-
-Por exemplo:
-
-```sh
-> make help
-help                           This help
-terraform-tfsec                Execute tfsec in terraform files
-terraform-validate             Execute terraform validate in terraform files
-terraform-clean                Remove terraform files untracked in git
-terraform-fmt                  Execute terraform fmt in terraform files
-terraform-generate-backend-gcs Generate file backend.tf
-terraform-init                 Execute terraform init in terraform files
-terraform-plan                 Execute terraform validate, tfsec and plan in terraform files
-terraform-apply                Execute terraform apply in terraform files
-terraform-destroy              Execute terraform destroy in terraform files
-fmt                            alias for terraform fmt
-plan                           Execute terraform fmt, init, plan in terraform files
-apply                          alias for terraform apply
-destroy                        alias for terraform destroy
-clean                          alias for terraform clean
-test                           Execute terraform plan, apply, destroy in terraform files
-```
-

--- a/examples/terraform/google-backend/README.md
+++ b/examples/terraform/google-backend/README.md
@@ -18,7 +18,7 @@ A implementação do Makefiles para Terraform está contida no arquivo `terrafor
 
 ### Configurando o arquivo .target.env
 
-Este arquivo deve conter, obrigatoriamente, as variáveis de ambiente (`BUCKET_NAME` e `GOOGLE_APPLICATION_CREDENTIALS`) utilizadas pelo Terraform para interagir Google Cloud Platform.
+Este arquivo deve conter, obrigatoriamente, as variáveis de ambiente (`BUCKET_NAME` e `GOOGLE_APPLICATION_CREDENTIALS`) utilizadas pelo Terraform para interagir com a Google Cloud Platform.
 
 Também podem ser informadas neste arquivo, quantas variáveis forem necessárias para consumo do módulo, no formato `TF_VAR_`, conforme [documentação oficial](https://www.terraform.io/docs/language/values/variables.html#environment-variables).
 

--- a/examples/terraform/google-backend/README.md
+++ b/examples/terraform/google-backend/README.md
@@ -18,12 +18,15 @@ A implementação do Makefiles para Terraform está contida no arquivo `terrafor
 
 ### Configurando o arquivo .target.env
 
-Este arquivo deve conter as variáveis de ambiente utilizadas pelo Terraform para interagir Google Cloud Platform:
+Este arquivo deve conter, obrigatoriamente, as variáveis de ambiente (`BUCKET_NAME` e `GOOGLE_APPLICATION_CREDENTIALS`) utilizadas pelo Terraform para interagir Google Cloud Platform.
+
+Também podem ser informadas neste arquivo, quantas variáveis forem necessárias para consumo do módulo, no formato `TF_VAR_`, conforme [documentação oficial](https://www.terraform.io/docs/language/values/variables.html#environment-variables).
 
 |   Variável                      |  Obrigatório   |  _Default_        | Descrição     |
 |    :---:                        |     :---:      |     :---:         | :---          |
 | BUCKET_NAME                     |   Sim          |                   | Nome do bucket na Google Cloud Storage. O bucket informado na deve existir na GCP. |
 | GOOGLE_APPLICATION_CREDENTIALS  |   Sim          |                   | Caminho local para o arquivo de credenciais da GCP no formato JSON.  |
+| TF_VAR_<nome>                   |                |                   | Variável de entrada do módulo utilizado.  |
 
 
 ### Criando o arquivo backend.tf

--- a/examples/terraform/google-backend/README.md
+++ b/examples/terraform/google-backend/README.md
@@ -24,10 +24,22 @@ Também podem ser informadas neste arquivo, quantas variáveis forem necessária
 
 |   Variável                      |  Obrigatório   |  _Default_        | Descrição     |
 |    :---:                        |     :---:      |     :---:         | :---          |
-| BUCKET_NAME                     |   Sim          |                   | Nome do bucket na Google Cloud Storage. O bucket informado na deve existir na GCP. |
-| GOOGLE_APPLICATION_CREDENTIALS  |   Sim          |                   | Caminho local para o arquivo de credenciais da GCP no formato JSON.  |
-| TF_VAR_<nome>                   |                |                   | Variável de entrada do módulo utilizado.  |
+| BUCKET_NAME                     |   Sim          |       n/a         | Nome do bucket na Google Cloud Storage. O bucket informado na deve existir na GCP. |
+| GOOGLE_APPLICATION_CREDENTIALS  |   Sim          |       n/a         | Caminho local para o arquivo de credenciais da GCP no formato JSON.  |
+| TF_VAR_\<nome>                  |   Não          |       n/a         | Variável de entrada do módulo utilizado.  |
 
+Por exemplo:
+
+```
+# Variáveis para backend GCP
+BUCKET_NAME=dummy-bucket
+GOOGLE_APPLICATION_CREDENTIALS=./dummy-file.json
+# Variáveis do módulo
+TF_VAR_nome=exemplo
+TF_VAR_numero=123
+TF_VAR_lista=['item', 'item2']
+
+```
 
 ### Criando o arquivo backend.tf
 

--- a/examples/terraform/local-backend/README.md
+++ b/examples/terraform/local-backend/README.md
@@ -15,9 +15,22 @@ A implementação do Makefiles para Terraform está contida no arquivo `terrafor
 
 ## Como utilizar o template
 
-### Configrando _backend_
+### Configurando o _backend_
 
 O Terraform trabalha com [_backend_](https://www.terraform.io/docs/language/settings/_backend_s/index.html) local ou remoto. Para usar este Makefile com **_backend_ local**, não é necessária nenhuma configuração adicional.
+
+### Configurando o arquivo .target.env
+
+Neste arquivo podem ser informadas quantas variáveis forem necessárias para consumo do módulo, no formato `TF_VAR_`, conforme [documentação oficial](https://www.terraform.io/docs/language/values/variables.html#environment-variables).
+
+Por exemplo:
+
+```
+TF_VAR_nome=exemplo
+TF_VAR_numero=123
+TF_VAR_lista=['item', 'item2']
+
+```
 
 ### Executando o Terraform
 

--- a/examples/terraform/local-backend/README.md
+++ b/examples/terraform/local-backend/README.md
@@ -17,7 +17,7 @@ A implementação do Makefiles para Terraform está contida no arquivo `terrafor
 
 ### Configurando o _backend_
 
-O Terraform trabalha com [_backend_](https://www.terraform.io/docs/language/settings/_backend_s/index.html) local ou remoto. Para usar este Makefile com **_backend_ local**, não é necessária nenhuma configuração adicional.
+Para usar este Makefile com **_backend_ local**, não é necessária nenhuma configuração adicional.
 
 ### Configurando o arquivo .target.env
 


### PR DESCRIPTION
Para usar módulos Terraform a partir desse Makefile, é necessário informar as variáveis de entrada (`TF_VAR_`) em um arquivo de envs chamado `.target.env`.

Esse PR tem como objetivo explicar esta opção de utilização das `TF_VAR_` e mostrar um exemplo para cada tipo de backend contido no repositório.

Também foram removidas algumas informações duplicadas entre os README's.