### PR TITLE
Adicionar variavel para subshell

### DIFF
--- a/terraform.inc
+++ b/terraform.inc
@@ -18,6 +18,16 @@ ifndef TFPLAN
 	TFPLAN=tfplan
 endif
 
+# Verify the OS
+UNAME := $(shell uname -s)
+ifeq ($(UNAME), Linux)
+    GET_ID := $(shell stat -c "%u:%g" ./)
+else ifeq ($(UNAME), Darwin)
+	GET_ID := $(shell stat -f "%u:%g" ./)
+else
+	ERROR := $(error Comando somente suportado em Linux/Mac)
+endif
+
 # HELP
 # This will output the help for each task
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -28,7 +38,7 @@ help: ## This help
 
 terraform-tfsec: ## Execute tfsec in terraform files
 	echo "STEP: terraform-tfsec - Execute tfsec in terraform files"
-	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app tfsec/tfsec `stat ./` . --no-color
+	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app -u $(GET_ID) tfsec/tfsec . --no-color
 
 terraform-validate: ## Execute terraform validate in terraform files
 	echo "STEP: terraform-validate - Execute terraform validate in terraform files"
@@ -52,19 +62,19 @@ terraform-generate-backend-gcs:  ## Generate file backend.tf on Google Cloud Sto
 
 terraform-init: ## Execute terraform init in terraform files
 	echo "STEP: terraform-init - Execute terraform init in terraform files"
-	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u `stat -c "%u:%g" ./` hashicorp/terraform:$(TERRAFORM_VERSION) init
+	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u $(GET_ID) hashicorp/terraform:$(TERRAFORM_VERSION) init
 
 terraform-plan: terraform-validate  ## Execute terraform validate, tfsec and plan in terraform files
 	echo "STEP: terraform-plan - Execute terraform validate, tfsec and plan in terraform files"
-	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u `stat -c "%u:%g" ./` hashicorp/terraform:$(TERRAFORM_VERSION) plan -out ${TFPLAN}
+	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u $(GET_ID) hashicorp/terraform:$(TERRAFORM_VERSION) plan -out ${TFPLAN}
 
 terraform-apply: ## Execute terraform apply in terraform files
 	echo "STEP: terraform-apply - Execute terraform apply in terraform files"
-	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u `stat -c "%u:%g" ./` hashicorp/terraform:$(TERRAFORM_VERSION) apply -auto-approve ${TFPLAN}
+	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u $(GET_ID) hashicorp/terraform:$(TERRAFORM_VERSION) apply -auto-approve ${TFPLAN}
 	
 terraform-destroy: ## Execute terraform destroy in terraform files
 	echo "STEP: terraform-destroy - Execute terraform destroy in terraform files"
-	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u `stat -c "%u:%g" ./` hashicorp/terraform:$(TERRAFORM_VERSION) destroy -auto-approve
+	docker run --rm -v $$PWD/${TARGET_FOLDER}:/app -w /app --env-file $(TARGET_ENV) -u $(GET_ID) hashicorp/terraform:$(TERRAFORM_VERSION) destroy -auto-approve
 
 fmt: terraform-fmt ## alias for terraform fmt
 plan: fmt terraform-init terraform-plan ## Execute terraform fmt, init, plan in terraform files


### PR DESCRIPTION
# Adicionar variavel para subshell

Revisores: @marcelomansur @snifbr @marlensouza

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Close #17 

## Objetivo

Adaptar o uso do comando `stat -c "%u:%g" ./` à uma variável em comum a todos os comandos, além de verificar compatibilidade do OS para tal.
Obs.: No OS Mac o comando o `stat` não tem a flag `-c` válida, por isto, foi utilizado: `shell stat -f "%u:%g" ./`

## Referências

Como fazer condicionais no Makefile 
https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html

## Como testar

<!-- Passo a passo -->

Acesse o caminho `Makefiles/examples/terraform/local-backend`

Rode o comando
```
make terraform-init
```

É esperado o retorno:
```
STEP: terraform-init - Execute terraform init in terraform files

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
